### PR TITLE
Add FastAPI-based Meeting Room Booking MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+booking.db
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# hackathon
+# Hackathon Meeting Room Booking Tool
+
+This project is a minimal MVP for reserving meeting rooms.
+
+## Backend
+
+* Python **FastAPI** with an SQLite database (file `booking.db`).
+* Basic CRUD endpoints for rooms and bookings.
+* Booking creation prevents overlapping bookings in the same room.
+
+Start the API:
+
+```bash
+python3 -m uvicorn backend.main:app --reload
+```
+
+API docs are available at `http://localhost:8000/docs`.
+
+## Frontend
+
+A simple HTML/JavaScript page is located in `frontend/index.html`.
+Open it in your browser after starting the backend. It calls the API to list
+and create rooms and bookings.
+
+## Tests
+
+Run unit tests with:
+
+```bash
+python3 -m pytest -q
+```

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,42 @@
+import sqlite3
+from contextlib import contextmanager
+
+DB_PATH = 'booking.db'
+
+def init_db():
+    """Create tables if they do not exist."""
+    conn = sqlite3.connect(DB_PATH)
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS rooms (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE
+        );
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS bookings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            room_id INTEGER NOT NULL,
+            title TEXT NOT NULL,
+            start DATETIME NOT NULL,
+            end DATETIME NOT NULL,
+            FOREIGN KEY (room_id) REFERENCES rooms(id)
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+# initialize at import
+init_db()
+
+@contextmanager
+def get_db():
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from fastapi import FastAPI, HTTPException
+from .models import RoomCreate, Room, BookingCreate, Booking
+from .service import RoomService, BookingService
+
+app = FastAPI(title="Meeting Room Booking API")
+
+@app.post("/rooms", response_model=Room)
+def create_room(room: RoomCreate):
+    room_id = RoomService.create_room(room.name)
+    return Room(id=room_id, **room.dict())
+
+@app.get("/rooms", response_model=list[Room])
+def list_rooms():
+    rooms = RoomService.list_rooms()
+    return [Room(**r) for r in rooms]
+
+@app.post("/bookings", response_model=Booking)
+def create_booking(b: BookingCreate):
+    try:
+        bid = BookingService.create_booking(b.room_id, b.title, b.start, b.end)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    return Booking(id=bid, **b.dict())
+
+@app.get("/bookings", response_model=list[Booking])
+def list_bookings():
+    bookings = BookingService.list_bookings()
+    # convert ISO strings to datetime
+    result = []
+    for row in bookings:
+        row['start'] = datetime.fromisoformat(row['start'])
+        row['end'] = datetime.fromisoformat(row['end'])
+        result.append(Booking(**row))
+    return result

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+from datetime import datetime
+
+class RoomCreate(BaseModel):
+    name: str
+
+class Room(RoomCreate):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+class BookingCreate(BaseModel):
+    room_id: int
+    title: str
+    start: datetime
+    end: datetime
+
+class Booking(BookingCreate):
+    id: int
+
+    class Config:
+        orm_mode = True

--- a/backend/service.py
+++ b/backend/service.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from .database import get_db
+
+class RoomService:
+    @staticmethod
+    def create_room(name: str) -> int:
+        with get_db() as db:
+            cur = db.execute("INSERT INTO rooms(name) VALUES (?)", (name,))
+            db.commit()
+            return cur.lastrowid
+
+    @staticmethod
+    def list_rooms():
+        with get_db() as db:
+            cur = db.execute("SELECT id, name FROM rooms")
+            return [dict(row) for row in cur.fetchall()]
+
+class BookingService:
+    @staticmethod
+    def create_booking(room_id: int, title: str, start: datetime, end: datetime) -> int:
+        if end <= start:
+            raise ValueError("End must be after start")
+        with get_db() as db:
+            # check overlap
+            cur = db.execute(
+                """SELECT 1 FROM bookings WHERE room_id=? AND NOT (end<=? OR start>=?)""",
+                (room_id, start.isoformat(), end.isoformat()),
+            )
+            if cur.fetchone():
+                raise ValueError("Booking overlaps with existing booking")
+            cur = db.execute(
+                "INSERT INTO bookings(room_id, title, start, end) VALUES (?,?,?,?)",
+                (room_id, title, start.isoformat(), end.isoformat()),
+            )
+            db.commit()
+            return cur.lastrowid
+
+    @staticmethod
+    def list_bookings():
+        with get_db() as db:
+            cur = db.execute("SELECT * FROM bookings")
+            rows = cur.fetchall()
+            return [dict(row) for row in rows]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Meeting Room Booking</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 2em; }
+label { display: block; margin-top: 1em; }
+</style>
+</head>
+<body>
+<h1>Rooms</h1>
+<ul id="rooms"></ul>
+<h2>Add Room</h2>
+<input id="roomName" placeholder="Room name">
+<button onclick="addRoom()">Add Room</button>
+<h1>Bookings</h1>
+<ul id="bookings"></ul>
+<h2>Add Booking</h2>
+<form id="bookingForm" onsubmit="createBooking(event)">
+<label>Room ID <input id="roomId" required></label>
+<label>Title <input id="title" required></label>
+<label>Start <input id="start" type="datetime-local" required></label>
+<label>End <input id="end" type="datetime-local" required></label>
+<button type="submit">Book</button>
+</form>
+<script>
+async function loadRooms(){
+  const res = await fetch('/rooms');
+  const data = await res.json();
+  const ul = document.getElementById('rooms');
+  ul.innerHTML = data.map(r => `<li>${r.id} - ${r.name}</li>`).join('');
+}
+async function addRoom(){
+  const name = document.getElementById('roomName').value;
+  await fetch('/rooms', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({name})});
+  loadRooms();
+}
+async function loadBookings(){
+  const res = await fetch('/bookings');
+  const data = await res.json();
+  const ul = document.getElementById('bookings');
+  ul.innerHTML = data.map(b => `<li>${b.title} (${b.start} - ${b.end})</li>`).join('');
+}
+async function createBooking(e){
+  e.preventDefault();
+  const body = {
+    room_id: parseInt(document.getElementById('roomId').value),
+    title: document.getElementById('title').value,
+    start: document.getElementById('start').value,
+    end: document.getElementById('end').value
+  };
+  const res = await fetch('/bookings', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(body)});
+  if(res.ok){
+    loadBookings();
+  }else{
+    const err = await res.json();
+    alert(err.detail);
+  }
+}
+loadRooms();
+loadBookings();
+</script>
+</body>
+</html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,34 @@
+import os
+import unittest
+from datetime import datetime, timedelta
+
+# ensure fresh DB
+if os.path.exists('booking.db'):
+    os.remove('booking.db')
+
+from backend.database import init_db
+from backend.service import RoomService, BookingService
+
+class BookingServiceTest(unittest.TestCase):
+    def setUp(self):
+        # start with a fresh database for each test
+        if os.path.exists('booking.db'):
+            os.remove('booking.db')
+        init_db()
+        self.room_id = RoomService.create_room('Room A')
+
+    def test_no_overlap(self):
+        start = datetime.now()
+        end = start + timedelta(hours=1)
+        booking_id = BookingService.create_booking(self.room_id, 'Meeting', start, end)
+        self.assertIsNotNone(booking_id)
+
+    def test_overlap(self):
+        start = datetime.now()
+        end = start + timedelta(hours=1)
+        BookingService.create_booking(self.room_id, 'First', start, end)
+        with self.assertRaises(ValueError):
+            BookingService.create_booking(self.room_id, 'Overlap', start + timedelta(minutes=30), end + timedelta(minutes=30))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement a simple FastAPI backend with SQLite for rooms and bookings
- enforce non-overlapping bookings in service layer
- add HTML/JS frontend for manual testing
- provide unit tests for booking logic
- document how to run server and tests

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c1ad89274832ba14551a1b2383506